### PR TITLE
chore: 수영 날짜 선택 필드의 화살표 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@
 
 🏊‍♂️ Swimie는 수영 기록을 간편하게 관리하고, 친구들과 응원을 주고받을 수 있는 커뮤니티 기반의 수영 기록 앱입니다. <br />
 수영이 더 즐거워지는 공간, 스위미에서 오늘의 수영을 기록하고✒️, 친구들의 응원과 함께 동기부여를 얻어보세요! 💪
+
 #### <a href="https://swimie.life">👉Swimie 바로가기</a>
+
 <br />
 
 ## ✨주요 기능
 
 ### 🦭달력과 타임라인을 통해 내 수영 기록을 시각적으로 확인할 수 있어요.
+
 ![swimie](https://github.com/user-attachments/assets/5c9b88ec-0e51-4ace-8e15-42a4bd01435d)
 
 ![swimie2](https://github.com/user-attachments/assets/acbb5d13-c2bd-4ee3-918a-7d0424abbb36)
@@ -23,13 +26,16 @@
 ![swimie4](https://github.com/user-attachments/assets/bad7149d-72a6-4695-83c9-c60c25ada78e)
 
 ### 🦭수영하는 친구들을 팔로우하고, 서로 응원을 나누며 더 큰 동기부여를 받을 수 있어요.
+
 ![swimie5](https://github.com/user-attachments/assets/aa19ce5a-5a60-425c-b364-1aafda4ab5e3)
 <br /><br />
 
 ## 📲 Contacts
 
 #### <a href="https://docs.google.com/forms/d/11b4SquXH_j-XMhXHK9XVwZTAmWfzllVbZsUZ_uPEPjo/edit">🤔 문의사항</a>
+
 #### <a href="https://www.instagram.com/swimie_app?igsh=MXh3MnJkMG50Y2xxbA%3D%3D&utm_source=qr">⭐️ 인스타그램</a>
+
 <br />
 
 ## 🛠️Tech Stack

--- a/components/molecules/text-field/select-text-field.tsx
+++ b/components/molecules/text-field/select-text-field.tsx
@@ -17,6 +17,7 @@ import { SelectTextFieldProps } from './type';
 //Todo: react-hook-form 내에서 사용이 아닌 다른 곳에서도 사용될 시, useController 외부에서 주입되도록 분리
 /**
  * @description react-hook-form 내에서 클릭 시, 바텀 시트 / 페이지 모달로 넘어가게 하기 위한 용도의 text-field 컴포넌트
+ * @param showArrow 화살표 표시 유무
  * @param label 라벨 이름
  * @param isRequired 필수 여부
  * @param subText 추가 설명 텍스트
@@ -29,6 +30,7 @@ import { SelectTextFieldProps } from './type';
  * @param onClick click 이벤트
  */
 export function SelectTextField({
+  showArrow = true,
   label,
   isRequired = false,
   subText,
@@ -67,9 +69,11 @@ export function SelectTextField({
         />
 
         {/* span태그 컴포넌트로 공통 생성 시 수정 */}
-        <span className={cx(absoluteStyles, absoluteClassName)}>
-          {<DownArrowIcon />}
-        </span>
+        {showArrow && (
+          <span className={cx(absoluteStyles, absoluteClassName)}>
+            {<DownArrowIcon />}
+          </span>
+        )}
       </div>
       <span className={cx(subTextStyles, subTextClassName)}>{subText}</span>
     </TextFieldWrapper>

--- a/components/molecules/text-field/type.ts
+++ b/components/molecules/text-field/type.ts
@@ -31,6 +31,7 @@ export interface SelectTextFieldProps
     TextFieldProps,
     'onChange' | 'inputType' | 'value' | 'unit' | 'maxLength' | 'registerName'
   > {
+  showArrow?: boolean;
   subFieldText?: string;
   fieldName?: string;
   onClick?: () => void;

--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -278,6 +278,7 @@ export function Form({ prevSwimStartTime, prevSwimEndTime }: FormProps) {
       <form onSubmit={methods.handleSubmit(onSubmit)}>
         <div className={cx(formSectionStyles)}>
           <SelectTextField
+            showArrow={false}
             fieldName="recordAt"
             isRequired
             label="수영 날짜"


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

## 🎉 어떻게 해결했나요?

- 수영 날짜 선택 필드의 화살표를 제거하기 위한 prop을 하나 추가해주었습니다.

### 📷 이미지 첨부 (Option)

<img width="284" alt="image" src="https://github.com/user-attachments/assets/b27f88a5-4d95-4caa-bb89-3e46e6ff81ee">

### ⚠️ 유의할 점! (Option)

- NA
