### PR TITLE
chore: 기록 생성 시 거리 기록 tabIndex 조건 수정 및 time-picker 디폴트 값 변경

### DIFF
--- a/features/record/constants/time.ts
+++ b/features/record/constants/time.ts
@@ -33,7 +33,7 @@ export const timeOptions = {
 };
 
 export const defaultPickerValue = {
-  ampm: '오후' as AmpmType,
-  hour: '02' as HourType,
-  minute: '05' as MinuteType,
+  ampm: '오전' as AmpmType,
+  hour: '09' as HourType,
+  minute: '00' as MinuteType,
 };

--- a/features/record/hooks/use-distance-page-modal.tsx
+++ b/features/record/hooks/use-distance-page-modal.tsx
@@ -30,10 +30,18 @@ export function useDistancePageModal<T>(
   const pageModalRef = useRef<T>(null);
   const setPageModalState = useSetAtom(isDistancePageModalOpen);
   const [secondaryTabIndex, setSecondaryTabIndex] = useState<tabIndex>(
-    isRecordedByTotalMeter || isRecordedByTotalLaps ? 0 : 1,
+    defaultTotalMeter
+      ? isRecordedByTotalMeter || isRecordedByTotalLaps
+        ? 0
+        : 1
+      : 0,
   );
   const [assistiveTabIndex, setAssistiveTabIndex] = useState<tabIndex>(
-    isRecordedByTotalMeter || isRecordedByStrokesMeter ? 0 : 1,
+    defaultTotalMeter
+      ? isRecordedByTotalMeter || isRecordedByStrokesMeter
+        ? 0
+        : 1
+      : 0,
   );
   const [totalMeter, setTotalMeter] = useState<string>('');
   const [totalLaps, setTotalLaps] = useState<string>('');


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

## 🎉 어떻게 해결했나요?

- 기록 생성 시 -> 모든 tabIndex가 0 &기록 수정 시 -> 각 상황에 맞게 tabIndex 디폴트 값을 설정

- time-picker 디폴트 값을 수정하였습니다.


### 📷 이미지 첨부 (Option)

- NA

### ⚠️ 유의할 점! (Option)

- NA
