### PR TITLE
fix: 첫 기록 시도 시, 마지막 시간이 +50분 자동 설정될 때 바텀시트에도 반영되도록 수정

### DIFF
--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -370,10 +370,7 @@ export function Form({ prevSwimStartTime, prevSwimEndTime }: FormProps) {
         defaultTotalLap={data?.data.totalLap}
         defaultTotalMeter={data?.data.totalMeter}
       />
-      <TimeBottomSheet
-        prevSwimStartTime={prevSwimStartTime}
-        prevSwimEndTime={prevSwimEndTime}
-      />
+      <TimeBottomSheet startTime={startTime} endTime={endTime} />
     </FormProvider>
   );
 }

--- a/features/record/components/organisms/time-bottom-sheet.tsx
+++ b/features/record/components/organisms/time-bottom-sheet.tsx
@@ -20,14 +20,11 @@ import {
 } from '../../utils';
 
 interface TimeBottomSheetProps {
-  prevSwimStartTime?: string;
-  prevSwimEndTime?: string;
+  startTime?: string;
+  endTime?: string;
 }
 
-export function TimeBottomSheet({
-  prevSwimStartTime,
-  prevSwimEndTime,
-}: TimeBottomSheetProps) {
+export function TimeBottomSheet({ startTime, endTime }: TimeBottomSheetProps) {
   const { getValues, setValue } = useFormContext();
   const [timeBottmSheetState, setTimeBottmSheetState] =
     useAtom(timeBottomSheetState);
@@ -39,10 +36,10 @@ export function TimeBottomSheet({
   }>(defaultPickerValue);
 
   useEffect(() => {
-    if (timeBottmSheetState.variant === 'start')
-      setPickerValue(convertToPickerValue(prevSwimStartTime));
-    if (timeBottmSheetState.variant === 'end')
-      setPickerValue(convertToPickerValue(prevSwimEndTime));
+    if (Boolean(startTime) && timeBottmSheetState.variant === 'start')
+      setPickerValue(convertToPickerValue(startTime));
+    if (Boolean(endTime) && timeBottmSheetState.variant === 'end')
+      setPickerValue(convertToPickerValue(endTime));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [timeBottmSheetState.variant]);
 


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 첫 기록에서 마지막 시간이 +50분 자동 설정 될 때, 바텀시트에는 반영이 안되는 현상이 있었습니다.

## 🎉 어떻게 해결했나요?

- 반영되도록 로직을 수정하였습니다.

### 📷 이미지 첨부 (Option)

- 첫 기록

https://github.com/user-attachments/assets/42c8c68f-8b4d-4e1a-9054-abb3f1646057

- 첫 기록 이후

https://github.com/user-attachments/assets/8c2c25bb-3d8b-426a-9f86-8e0af90e1892

- 수정

https://github.com/user-attachments/assets/27a94dab-2bd7-4c7c-821d-e7a8c26c1cdf

### ⚠️ 유의할 점! (Option)

- NA
