### PR TITLE
chore: 이미지 깨짐 현상 수정을 위한 시도

### DIFF
--- a/features/notification/components/molecules/follow-notification.tsx
+++ b/features/notification/components/molecules/follow-notification.tsx
@@ -7,13 +7,11 @@ import { useMemberFollowingState } from '@/hooks';
 import { css, cva } from '@/styled-system/css';
 import { convertTimeToElapsedTime } from '@/utils';
 
-import { useReadNotification } from '../../apis/use-read-notification';
 import { layoutStyles, textStyles } from '../../styles';
 import { FollowNotificationProps } from '../../types';
 
 export function FollowNotification({
   memberId,
-  notificationId,
   type,
   hasRead,
   profileImageUrl,
@@ -22,11 +20,6 @@ export function FollowNotification({
 }: FollowNotificationProps) {
   const { useMemberIsFollowing, toggleFollow } = useMemberFollowingState();
   const { isFollowing } = useMemberIsFollowing(memberId);
-  const { mutate: readNotification } = useReadNotification();
-
-  const handleListElementClick = () => {
-    readNotification({ notificationId, type });
-  };
 
   const handleFollowButtonClick = () => {
     void toggleFollow(memberId);
@@ -34,11 +27,7 @@ export function FollowNotification({
 
   return (
     <li className={css(layoutStyles.total.raw({ hasRead }))}>
-      <Link
-        href={`/profile/${memberId}`}
-        onClick={handleListElementClick}
-        className={css({ display: 'flex' })}
-      >
+      <Link href={`/profile/${memberId}`} className={css({ display: 'flex' })}>
         <div className={profileImageStyles}>
           <ProfileImage
             alt="프로필 사진"

--- a/features/record/components/organisms/photo-section.tsx
+++ b/features/record/components/organisms/photo-section.tsx
@@ -37,7 +37,7 @@ export function PhotoSection({
       try {
         if (e.target.files) {
           const targetFile = e.target.files[0];
-          const resizedImage = await resizeFile(targetFile, 600, 600, 100);
+          const resizedImage = await resizeFile(targetFile, 800, 1000, 100);
           setFormSubInfo((prev) => ({
             ...prev,
             imageFiles: [...prev.imageFiles, resizedImage],


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 간혹 업로드 된 이미지가 깨진다는 QA가 들어왔습니다.

## 🎉 어떻게 해결했나요?

- 업로드 전에 프론트 측에서 진행하는 resizing 과정에서 크기가 너무 딱 맞춰져 있는 게 원인일 수도 있겠다는 생각이 들었습니다. 해당 크기를 좀 더 넉넉히 설정해 주었습니다.

### 📷 이미지 첨부 (Option)

- NA

### ⚠️ 유의할 점! (Option)

- NA

