### PR TITLE
fix: 자기소개가 긴 경우 프로필 사진이 찌그러지는 현상 수정

### DIFF
--- a/features/notification/components/molecules/follow-notification.tsx
+++ b/features/notification/components/molecules/follow-notification.tsx
@@ -7,13 +7,11 @@ import { useMemberFollowingState } from '@/hooks';
 import { css, cva } from '@/styled-system/css';
 import { convertTimeToElapsedTime } from '@/utils';
 
-import { useReadNotification } from '../../apis/use-read-notification';
 import { layoutStyles, textStyles } from '../../styles';
 import { FollowNotificationProps } from '../../types';
 
 export function FollowNotification({
   memberId,
-  notificationId,
   type,
   hasRead,
   profileImageUrl,
@@ -22,11 +20,6 @@ export function FollowNotification({
 }: FollowNotificationProps) {
   const { useMemberIsFollowing, toggleFollow } = useMemberFollowingState();
   const { isFollowing } = useMemberIsFollowing(memberId);
-  const { mutate: readNotification } = useReadNotification();
-
-  const handleListElementClick = () => {
-    readNotification({ notificationId, type });
-  };
 
   const handleFollowButtonClick = () => {
     void toggleFollow(memberId);
@@ -34,11 +27,7 @@ export function FollowNotification({
 
   return (
     <li className={css(layoutStyles.total.raw({ hasRead }))}>
-      <Link
-        href={`/profile/${memberId}`}
-        onClick={handleListElementClick}
-        className={css({ display: 'flex' })}
-      >
+      <Link href={`/profile/${memberId}`} className={css({ display: 'flex' })}>
         <div className={profileImageStyles}>
           <ProfileImage
             alt="프로필 사진"

--- a/features/profile/components/organisms/profile-container.tsx
+++ b/features/profile/components/organisms/profile-container.tsx
@@ -20,7 +20,10 @@ export function ProfileContainer({
             src={profileData.profileImageUrl}
             fill
             sizes="10vw"
-            className={css({ borderRadius: 'full', objectFit: 'cover' })}
+            className={css({
+              borderRadius: 'full',
+              objectFit: 'cover',
+            })}
           />
         </div>
         <div>
@@ -52,6 +55,7 @@ const imageLayoutStyles = css({
   width: '60px',
   height: '60px',
   position: 'relative',
+  flexShrink: 0,
 });
 
 const inforWrapper = flex({


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 자기소개가 긴 경우 프로필 사진이 찌그러지는 현상이 있었습니다.

## 🎉 어떻게 해결했나요?

- flexShrink:0을 추가해주었습니다.

### 📷 이미지 첨부 (Option)

<img width="350" alt="image" src="https://github.com/user-attachments/assets/fb14e3e3-ae1c-4c9c-abba-607ebfaa6cb7">

<img width="298" alt="image" src="https://github.com/user-attachments/assets/0c904829-72cb-43fa-91df-021cee8adc48">

### ⚠️ 유의할 점! (Option)

- NA
