### PR TITLE
fix: 팔로우/언팔로우 시 데이터 실시간 반영

### DIFF
--- a/features/profile/hooks/use-profile-data.tsx
+++ b/features/profile/hooks/use-profile-data.tsx
@@ -12,6 +12,6 @@ export const useProfileData = (id?: number) => {
         return data.data;
       }),
     enabled: !!id,
-    staleTime: Infinity,
+    // staleTime: Infinity,
   });
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 팔로우/언팔로우 시 프로필의 숫자가 바로 반영되지 않고, 페이지를 이탈해야만 확인할 수 있습니다.
- fetchProfileData에 staleTime이 infinity로, 캐싱이 되어 있는 게 원인이었습니다.

## 🎉 어떻게 해결했나요?

- 바람직하진 않지만 매 요청을 다시 보내도록 staleTime을 삭제했습니다.
- 해당 부분은 팔로우/언팔로우 시 우선 ui에서 업데이트를 진행하는 낙관적 업데이트로 추후 수정하면 좋을 것 같습니다!

### 📷 이미지 첨부 (Option)


Uploading 화면 기록 2024-11-12 오후 8.52.21.mov…


### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
